### PR TITLE
Improvement/usability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "^13.0.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hot-toast": "^2.4.0",
     "react-icons": "^4.7.1"
   },
   "devDependencies": {

--- a/src/TopPage.tsx
+++ b/src/TopPage.tsx
@@ -81,6 +81,9 @@ const NewProjectButton = styled("button", {
   borderRadius: "44px",
   border: "none",
   margin: "30px auto",
+  "&:active": {
+    background: "$yellow900-reaction",
+  },
 });
 
 const Section = styled("div", {

--- a/src/common/Loading.css
+++ b/src/common/Loading.css
@@ -1,0 +1,35 @@
+@keyframes spin {
+  from {
+    transform: rotate(0);
+  }
+  to{
+    transform: rotate(359deg);
+  }
+}
+
+
+.spinner-box {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+}
+.circle-border {
+  width: 50px;
+  height: 50px;
+  padding: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background: linear-gradient(0deg, rgba(221,186,62,0.1) 33%, #DDBA3E 100%);
+  animation: spin .8s linear 0s infinite;
+}
+
+.circle-core {
+  width: 100%;
+  height: 100%;
+  background-color: #EAE9E7; /* gray200 */
+  border-radius: 50%;
+}

--- a/src/common/Loading.stories.tsx
+++ b/src/common/Loading.stories.tsx
@@ -1,0 +1,15 @@
+import type { ComponentMeta, ComponentStoryObj } from "@storybook/react";
+
+import { Loading } from "./Loading";
+
+type Meta = ComponentMeta<typeof Loading>;
+
+const meta: Meta = {
+  component: Loading,
+  decorators: [],
+  args: {},
+};
+
+export default meta;
+
+export const Default: ComponentStoryObj<typeof Loading> = {};

--- a/src/common/Loading.tsx
+++ b/src/common/Loading.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { styled } from "../stitches.config";
+import "./Loading.css";
+
+type Props = {
+  text?: string;
+};
+
+export const Loading: React.FC<Props> = ({ text }) => {
+  return (
+    <LoadingWrapper>
+      <div className="spinner-box">
+        <div className="circle-border">
+          <div className="circle-core"></div>
+        </div>
+      </div>
+      {text && <Text>{text}</Text>}
+    </LoadingWrapper>
+  );
+};
+
+const LoadingWrapper = styled("div", {
+  background: "$gray200",
+  padding: "16px",
+  borderRadius: "8px",
+});
+
+const Text = styled("p", {
+  fontSize: "14px",
+  color: "$textSecondary",
+  textAlign: "center",
+  fontWeight: "600",
+});

--- a/src/newProject/NewProjectPage.tsx
+++ b/src/newProject/NewProjectPage.tsx
@@ -7,28 +7,36 @@ import { createProject } from "../utils/apis";
 const receiverNamePlaceholder = "山田 太郎";
 
 export const NewProjectPage: React.FC = () => {
-  const [receiverName, setReceiverName] = useState("");
+  const [nameInputStatus, setNameInputStatus] = useState({ name: "", isTouched: false });
   const router = useRouter();
 
   const registerProject = async () => {
     if (!canRegister) return;
-    const project_id = await createProject(receiverName);
+    const project_id = await createProject(nameInputStatus.name);
     router.push(`/projects/${project_id}`);
   };
 
-  const canRegister = receiverName !== "";
+  const canRegister = nameInputStatus.name !== "";
 
+  // TODO: 文言が今のコンセプトにはあってないのでそのあたりを修正する
   return (
     <>
       <Base>
         <div>
           <PageTitle>色紙を作成する</PageTitle>
           <Discription>ここで入力されたお名前はページが公開されるときにも使用されます。</Discription>
+          <Label htmlFor="name">お名前</Label>
           <InputName
-            value={receiverName}
+            name="name"
+            value={nameInputStatus.name}
             placeholder={receiverNamePlaceholder}
-            onChange={(e) => setReceiverName(e.target.value)}
+            onChange={(e) => setNameInputStatus({ name: e.target.value, isTouched: true })}
           />
+          <InvalidMessageWrapper>
+            <InvalidMessage aria-live="polite" hidden={!(nameInputStatus.name === "" && nameInputStatus.isTouched)}>
+              1文字以上入力してください。
+            </InvalidMessage>
+          </InvalidMessageWrapper>
         </div>
         <NewProjectButton onClick={registerProject} disabled={!canRegister}>
           色紙を作成する
@@ -57,7 +65,12 @@ const PageTitle = styled("p", {
 const Discription = styled("p", {
   textAlign: "left",
   fontSize: "14px",
-  margin: "8px auto 0",
+  margin: "8px auto 16px",
+  color: "$textPrimary",
+});
+
+const Label = styled("label", {
+  fontSize: "12px",
   color: "$textPrimary",
 });
 
@@ -70,15 +83,18 @@ const InputName = styled("input", {
   borderRadius: "4px",
   boxSizing: "border-box",
   paddingLeft: "8px",
-  margin: "20px auto 0",
-  "&:focus-visible, &:focus": {
-    outline: "none",
-  },
 });
 
-// const InputNameWrapper = styled("div", {
-//   marginTop: "16px",
-// });
+const InvalidMessageWrapper = styled("div", {
+  height: "32px",
+  margin: "4px 0 0 0",
+});
+
+const InvalidMessage = styled("p", {
+  fontSize: "12px",
+  color: "$alert",
+  margin: "unset",
+});
 
 const NewProjectButton = styled("button", {
   color: "#FFFFFF",
@@ -97,5 +113,8 @@ const NewProjectButton = styled("button", {
   left: 0,
   "&:active": {
     background: "$yellow900-reaction",
+  },
+  "&:disabled": {
+    background: "$gray400",
   },
 });

--- a/src/newProject/NewProjectPage.tsx
+++ b/src/newProject/NewProjectPage.tsx
@@ -95,4 +95,7 @@ const NewProjectButton = styled("button", {
   position: "absolute",
   bottom: 0,
   left: 0,
+  "&:active": {
+    background: "$yellow900-reaction",
+  },
 });

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -42,6 +42,8 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
       gray700: "#5B5A58",
       gray800: "#3C3B3A",
       gray900: "#1C1B1A",
+
+      alert: "#8E2C2C",
     },
     fonts: {},
   },

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -19,6 +19,7 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
       yellow700: "#C8A538",
       yellow800: "#B28F34",
       yellow900: "#8E6C2C",
+      "yellow900-reaction": "#654D1F",
 
       blue50: "#E5F3FB",
       blue100: "#C1E0F6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7186,6 +7186,11 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+goober@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.11.tgz#bbd71f90d2df725397340f808dbe7acc3118e610"
+  integrity sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz"
@@ -10899,6 +10904,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-hot-toast@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.0.tgz#b91e7a4c1b6e3068fc599d3d83b4fb48668ae51d"
+  integrity sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.7.1:
   version "4.7.1"


### PR DESCRIPTION
#32 

## 作成画面
[8ada927](https://github.com/youngeek-0410/hacku-kosen-2022-frontend/pull/36/commits/8ada927765c8ea567245eba167c73d37e8246675)
- ボタンのdisabled状態を定義
- 入力されていない時に「1文字以上入力してください。」のテキストを表示

<img width="30%" src="https://user-images.githubusercontent.com/60056125/208107345-ae59939b-863a-4c59-abd8-cb5d4f4e4726.png" />

## Loadingコンポーネント
[949ff48](https://github.com/youngeek-0410/hacku-kosen-2022-frontend/pull/36/commits/949ff48edfc3264c07a623b126bffc2468a12b06)
- コンポーネントWrapしてwidthは調整してください
- propsでtext入れることを推奨します
![image](https://user-images.githubusercontent.com/60056125/208127474-eb611496-7b6f-4b4d-bcc4-0c419397ffa6.png)

## Toast
https://react-hot-toast.com/
↑これぶち込んだ。使いたいところで使ってもらえれば